### PR TITLE
refactor: externalize locale and profile data

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,124 +9,23 @@ import Experience from "./components/Experience";
 import Education from "./components/Education";
 import Contact from "./components/Contact";
 import Highlights from "./components/Highlights";
-
-// --- Textos ES/EN ---
-const es = {
-  role: "Desarrollador Web / Estudiante",
-  about:
-    "Full-stack junior con foco en front-end moderno. Me muevo cómodo con React, Vite, Tailwind y Firebase/Mongo. Fan de las UIs limpias y que cargan en un suspiro.",
-  ctaContact: "Contactar",
-  ctaDownload: "Descargar JSON",
-  ctaPrint: "Imprimir PDF",
-  ctaShare: "Compartir",
-  ctaLang: "ES",
-  skills: "Habilidades",
-  projects: "Proyectos Destacados",
-  experience: "Experiencia",
-  education: "Educación",
-  contact: "Contacto",
-  years: "años",
-};
-
-const en = {
-  role: "Web Developer / Student",
-  about:
-    "Junior full-stack focused on modern front-end. Comfortable with React, Vite, Tailwind and Firebase/Mongo. I love clean UIs that load fast.",
-  ctaContact: "Contact",
-  ctaDownload: "Download JSON",
-  ctaPrint: "Print PDF",
-  ctaShare: "Share",
-  ctaLang: "EN",
-  skills: "Skills",
-  projects: "Featured Projects",
-  experience: "Experience",
-  education: "Education",
-  contact: "Contact",
-  years: "yrs",
-};
-
-// --- Datos iniciales (editalos) ---
-const initialData = {
-  name: "Gonzalo",
-  headline: "Construyo interfaces rápidas y con estilo.",
-  location: "La Rioja, AR",
-  email: "gonzalo@example.com",
-  phone: "+54 380 123 4567",
-  site: "https://tu-portfolio.dev",
-  socials: [
-    { label: "GitHub", href: "https://github.com/tuusuario", icon: Github },
-    { label: "LinkedIn", href: "https://linkedin.com/in/tuusuario", icon: Linkedin },
-  ],
-  skills: [
-    { name: "React (Vite)", level: 85 },
-    { name: "Tailwind CSS", level: 90 },
-    { name: "JavaScript/TypeScript", level: 80 },
-    { name: "Node.js", level: 70 },
-    { name: "Firebase/Mongo", level: 70 },
-    { name: "Git & Vercel", level: 75 },
-  ],
-  projects: [
-    {
-      title: "Rapitaxi — MVP ride-hailing",
-      description:
-        "Prototipo tipo Uber con flujo A→B, cálculo de tarifa, asignación de conductor y soporte desde central.",
-      tags: ["React", "Tailwind", "Firebase"],
-      link: "https://rapitaxi.example.com",
-    },
-    {
-      title: "POS Carnicería — Panel de ventas",
-      description:
-        "Panel para gestión de productos, ventas y caja diaria. Firestore + Realtime DB sin conflictos.",
-      tags: ["React", "Vite", "Firestore", "RTDB"],
-      link: "https://carniceria-panel.example.com",
-    },
-    {
-      title: "Barber Turnos — Agenda online",
-      description:
-        "Sistema de turnos con recordatorios, escáner QR y dashboard. Desplegado en Vercel.",
-      tags: ["React", "Tailwind", "Vercel"],
-      link: "https://barber-turnos.example.com",
-    },
-  ],
-  experience: [
-    {
-      company: "Telecom — Auditorías FTTH/HFC",
-      role: "Técnico / Auditor NAPs",
-      start: "2024",
-      end: "Actualidad",
-      summary:
-        "Optimización de procesos con apps internas (QR, escaneo, etiquetado). Mejora de tiempos y trazabilidad.",
-    },
-    {
-      company: "Proyectos académicos",
-      role: "Full-Stack Jr",
-      start: "2023",
-      end: "2024",
-      summary:
-        "CRUDs con Mongo/Mongoose, APIs Express y front con React + Tailwind. Deploys en Vercel/Render.",
-    },
-  ],
-  education: [
-    {
-      place: "Universidad — Programación / Redes",
-      degree: "Estudiante",
-      start: "2023",
-      end: "Actualidad",
-    },
-  ],
-  highlights: [
-    { label: "Proyectos", value: 12 },
-    { label: "Repos", value: 25 },
-    { label: "Clientes/Usuarios", value: 8 },
-  ],
-};
+import es from "./locales/es.json";
+import en from "./locales/en.json";
+import profile from "./data/profile.json";
+const ICONS = { Github, Linkedin };
 
 export default function App() {
   const [theme, setTheme] = useState("dark");
   const [lang, setLang] = useState("es");
   const [fancy, setFancy] = useState(true);
   const t = lang === "es" ? es : en;
-  const data = useMemo(() => initialData, []);
+  const data = useMemo(
+    () => ({
+      ...profile,
+      socials: profile.socials.map((s) => ({ ...s, icon: ICONS[s.icon] })),
+    }),
+    []
+  );
 
   return (
     <div className={theme === "dark" ? "dark" : ""}>

--- a/src/data/profile.json
+++ b/src/data/profile.json
@@ -1,0 +1,69 @@
+{
+  "name": "Gonzalo",
+  "headline": "Construyo interfaces rápidas y con estilo.",
+  "location": "La Rioja, AR",
+  "email": "gonzalo@example.com",
+  "phone": "+54 380 123 4567",
+  "site": "https://tu-portfolio.dev",
+  "socials": [
+    { "label": "GitHub", "href": "https://github.com/tuusuario", "icon": "Github" },
+    { "label": "LinkedIn", "href": "https://linkedin.com/in/tuusuario", "icon": "Linkedin" }
+  ],
+  "skills": [
+    { "name": "React (Vite)", "level": 85 },
+    { "name": "Tailwind CSS", "level": 90 },
+    { "name": "JavaScript/TypeScript", "level": 80 },
+    { "name": "Node.js", "level": 70 },
+    { "name": "Firebase/Mongo", "level": 70 },
+    { "name": "Git & Vercel", "level": 75 }
+  ],
+  "projects": [
+    {
+      "title": "Rapitaxi — MVP ride-hailing",
+      "description": "Prototipo tipo Uber con flujo A→B, cálculo de tarifa, asignación de conductor y soporte desde central.",
+      "tags": ["React", "Tailwind", "Firebase"],
+      "link": "https://rapitaxi.example.com"
+    },
+    {
+      "title": "POS Carnicería — Panel de ventas",
+      "description": "Panel para gestión de productos, ventas y caja diaria. Firestore + Realtime DB sin conflictos.",
+      "tags": ["React", "Vite", "Firestore", "RTDB"],
+      "link": "https://carniceria-panel.example.com"
+    },
+    {
+      "title": "Barber Turnos — Agenda online",
+      "description": "Sistema de turnos con recordatorios, escáner QR y dashboard. Desplegado en Vercel.",
+      "tags": ["React", "Tailwind", "Vercel"],
+      "link": "https://barber-turnos.example.com"
+    }
+  ],
+  "experience": [
+    {
+      "company": "Telecom — Auditorías FTTH/HFC",
+      "role": "Técnico / Auditor NAPs",
+      "start": "2024",
+      "end": "Actualidad",
+      "summary": "Optimización de procesos con apps internas (QR, escaneo, etiquetado). Mejora de tiempos y trazabilidad."
+    },
+    {
+      "company": "Proyectos académicos",
+      "role": "Full-Stack Jr",
+      "start": "2023",
+      "end": "2024",
+      "summary": "CRUDs con Mongo/Mongoose, APIs Express y front con React + Tailwind. Deploys en Vercel/Render."
+    }
+  ],
+  "education": [
+    {
+      "place": "Universidad — Programación / Redes",
+      "degree": "Estudiante",
+      "start": "2023",
+      "end": "Actualidad"
+    }
+  ],
+  "highlights": [
+    { "label": "Proyectos", "value": 12 },
+    { "label": "Repos", "value": 25 },
+    { "label": "Clientes/Usuarios", "value": 8 }
+  ]
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,15 @@
+{
+  "role": "Web Developer / Student",
+  "about": "Junior full-stack focused on modern front-end. Comfortable with React, Vite, Tailwind and Firebase/Mongo. I love clean UIs that load fast.",
+  "ctaContact": "Contact",
+  "ctaDownload": "Download JSON",
+  "ctaPrint": "Print PDF",
+  "ctaShare": "Share",
+  "ctaLang": "EN",
+  "skills": "Skills",
+  "projects": "Featured Projects",
+  "experience": "Experience",
+  "education": "Education",
+  "contact": "Contact",
+  "years": "yrs"
+}

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,0 +1,15 @@
+{
+  "role": "Desarrollador Web / Estudiante",
+  "about": "Full-stack junior con foco en front-end moderno. Me muevo cómodo con React, Vite, Tailwind y Firebase/Mongo. Fan de las UIs limpias y que cargan en un suspiro.",
+  "ctaContact": "Contactar",
+  "ctaDownload": "Descargar JSON",
+  "ctaPrint": "Imprimir PDF",
+  "ctaShare": "Compartir",
+  "ctaLang": "ES",
+  "skills": "Habilidades",
+  "projects": "Proyectos Destacados",
+  "experience": "Experiencia",
+  "education": "Educación",
+  "contact": "Contacto",
+  "years": "años"
+}


### PR DESCRIPTION
## Summary
- move Spanish and English text constants to `src/locales/es.json` and `src/locales/en.json`
- extract profile content into `src/data/profile.json`
- load locale and profile data in `App.jsx` based on selected language and map social icons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0f60d842c832cb05ba0b692e3a29b